### PR TITLE
Add downloads page with release and API links

### DIFF
--- a/css/downloads.css
+++ b/css/downloads.css
@@ -1,0 +1,34 @@
+/**
+ * downloads.css - Styles specific to downloads page
+ */
+
+.downloads-section {
+    padding: 4rem 0;
+}
+
+.download-list,
+.api-list {
+    list-style: none;
+    margin: 1.5rem 0;
+    padding-left: 0;
+}
+
+.download-list li,
+.api-list li {
+    margin-bottom: 0.5rem;
+}
+
+.download-list a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.download-list a:hover {
+    text-decoration: underline;
+}
+
+.api-list code {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+}

--- a/downloads.php
+++ b/downloads.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * downloads.php - Downloads and API reference page
+ * Author: ChatGPT
+ * Provides links to release artifacts and API endpoints.
+ */
+
+require_once 'header.php';
+?>
+
+<section class="downloads-section">
+    <div class="container">
+        <h1>Downloads &amp; API</h1>
+        <p>Get the latest release artifacts and explore the REST API for the Stargate Framework.</p>
+
+        <h2>GitHub Releases</h2>
+        <ul class="download-list">
+            <li><a href="https://github.com/davestj/stargate-framework/releases/latest" target="_blank" rel="noopener">Latest Release</a></li>
+            <li><a href="https://github.com/davestj/stargate-framework/archive/refs/heads/main.zip" target="_blank" rel="noopener">Source Code (ZIP)</a></li>
+            <li><a href="https://github.com/davestj/stargate-framework/archive/refs/heads/main.tar.gz" target="_blank" rel="noopener">Source Code (TAR.GZ)</a></li>
+        </ul>
+
+        <h2>API Endpoints</h2>
+        <p>The following endpoints are available under <code>/api/v1/</code>:</p>
+        <ul class="api-list">
+            <li><a href="/api/v1/stargate/activate"><code>POST /api/v1/stargate/activate</code></a> – Initiate stargate activation sequence.</li>
+            <li><a href="/api/v1/stargate/status"><code>GET /api/v1/stargate/status</code></a> – Retrieve current stargate status.</li>
+            <li><a href="/api/v1/stargate/deactivate"><code>POST /api/v1/stargate/deactivate</code></a> – Shutdown active stargate.</li>
+        </ul>
+    </div>
+</section>
+
+<?php
+require_once 'footer.php';
+?>


### PR DESCRIPTION
## Summary
- Add `downloads.php` page linking to GitHub release artifacts and `/api/v1` REST endpoints
- Style downloads page with new `css/downloads.css`

## Testing
- `php -l downloads.php`
- `php -l header.php footer.php`


------
https://chatgpt.com/codex/tasks/task_e_6898e1763b00832b9a810011c7944d92