### PR TITLE
Add downloads page to site navigation

### DIFF
--- a/header.php
+++ b/header.php
@@ -64,6 +64,9 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 <li class="nav-item <?php echo ($current_page == 'executive_summary_generator') ? 'active' : ''; ?>">
                     <a href="executive_summary_generator.php">Summaries</a>
                 </li>
+                <li class="nav-item <?php echo ($current_page == 'downloads') ? 'active' : ''; ?>">
+                    <a href="downloads.php">Downloads</a>
+                </li>
                 <li class="nav-item <?php echo ($current_page == 'technical_docs') ? 'active' : ''; ?>">
                     <a href="technical_docs.php">Documentation</a>
                 </li>


### PR DESCRIPTION
## Summary
- Add Downloads link to header navigation with active-page highlighting
- Mobile menu toggle continues to handle navigation items including Downloads

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_6898e3be8180832bb02c808d8638da2d