### PR TITLE
Add reactor control dashboard with metrics and live update support

### DIFF
--- a/css/reactor_control.css
+++ b/css/reactor_control.css
@@ -1,0 +1,45 @@
+/**
+ * reactor_control.css - Styles for Reactor Control Dashboard
+ */
+
+.reactor-dashboard {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.health-status {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.metric-card {
+    background: #ffffff;
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+.metric-card h3 {
+    margin-bottom: 1rem;
+    color: #2c3e50;
+}
+
+.metric-value {
+    font-size: 2rem;
+    font-weight: bold;
+    color: #3498db;
+}
+
+@media (max-width: 768px) {
+    .metrics-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/js/reactor_control.js
+++ b/js/reactor_control.js
@@ -1,0 +1,88 @@
+/**
+ * reactor_control.js - Client-side logic for Reactor Control Dashboard
+ * Handles REST API polling and optional WebSocket updates.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    fetchAll();
+    // Poll metrics periodically as a fallback
+    setInterval(fetchMetrics, 5000);
+    initWebSocket();
+});
+
+async function fetchAll() {
+    fetchHealth();
+    fetchStatus();
+    fetchMetrics();
+}
+
+async function fetchHealth() {
+    try {
+        const res = await fetch('/api/v1/health');
+        const data = await res.json();
+        document.getElementById('health-value').textContent = data.health || 'unknown';
+    } catch (err) {
+        console.error('Health fetch failed', err);
+    }
+}
+
+async function fetchStatus() {
+    try {
+        const res = await fetch('/api/v1/status');
+        const data = await res.json();
+        document.getElementById('status-value').textContent = data.status || 'unknown';
+    } catch (err) {
+        console.error('Status fetch failed', err);
+    }
+}
+
+async function fetchMetrics() {
+    try {
+        const res = await fetch('/api/v1/metrics');
+        const data = await res.json();
+        updateMetrics(data);
+    } catch (err) {
+        console.error('Metrics fetch failed', err);
+    }
+}
+
+function updateMetrics(data) {
+    if (!data) return;
+    if (data.cpu !== undefined) {
+        document.getElementById('cpu-usage').textContent = `${data.cpu}%`;
+    }
+    if (data.memory !== undefined) {
+        document.getElementById('memory-usage').textContent = `${data.memory} MB`;
+    }
+    if (data.event_rate !== undefined) {
+        document.getElementById('event-rate').textContent = `${data.event_rate} /s`;
+    }
+}
+
+function initWebSocket() {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const wsUrl = `${protocol}://${window.location.host}/ws/reactor`;
+    try {
+        const ws = new WebSocket(wsUrl);
+        ws.onmessage = event => {
+            try {
+                const data = JSON.parse(event.data);
+                if (data.type === 'metrics') {
+                    updateMetrics(data.payload);
+                }
+                if (data.type === 'health') {
+                    document.getElementById('health-value').textContent = data.payload;
+                }
+                if (data.type === 'status') {
+                    document.getElementById('status-value').textContent = data.payload;
+                }
+            } catch (e) {
+                console.warn('Invalid WS data', e);
+            }
+        };
+        ws.onopen = () => console.log('WebSocket connected');
+        ws.onerror = err => console.error('WebSocket error', err);
+    } catch (e) {
+        console.warn('WebSocket not available', e);
+    }
+}

--- a/reactor_control.php
+++ b/reactor_control.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * reactor_control.php - Reactor Control Dashboard
+ * Author: OpenAI ChatGPT
+ * Description: Monitors reactor health and metrics with optional live updates.
+ */
+
+// Include the shared header
+require_once 'header.php';
+?>
+
+<section class="reactor-dashboard">
+    <h1>Reactor Control Dashboard</h1>
+    <div class="health-status">
+        <h2>System Health: <span id="health-value">--</span></h2>
+        <p>Status: <span id="status-value">--</span></p>
+    </div>
+    <div class="metrics-grid">
+        <div class="metric-card">
+            <h3>CPU Usage</h3>
+            <div class="metric-value" id="cpu-usage">--%</div>
+        </div>
+        <div class="metric-card">
+            <h3>Memory Usage</h3>
+            <div class="metric-value" id="memory-usage">-- MB</div>
+        </div>
+        <div class="metric-card">
+            <h3>Event Rate</h3>
+            <div class="metric-value" id="event-rate">-- /s</div>
+        </div>
+    </div>
+</section>
+
+<?php
+// Include the shared footer
+require_once 'footer.php';
+?>


### PR DESCRIPTION
## Summary
- Create `reactor_control.php` using shared header/footer and dashboard layout for health, status, and system metrics
- Implement `reactor_control.js` to poll `/api/v1/health`, `/api/v1/status`, and `/api/v1/metrics`, with optional WebSocket updates
- Add basic styling in `reactor_control.css` for metric cards and grid layout

## Testing
- `php -l reactor_control.php`
- `node --check js/reactor_control.js`

------
https://chatgpt.com/codex/tasks/task_e_6898e55439d8832b8a16cfb737bf63db