### PR TITLE
docs: add download and control panel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,13 @@ We invite participation from:
 
 Access release packages and monitor system health using the built-in tools:
 
-- **Downloads Page**: Visit [`downloads.php`](downloads.php) for links to the latest releases and a quick overview of available REST endpoints.
+- **Downloads Page**: Visit [`downloads.php`](downloads.php) to download the latest release packages and review available REST endpoints.
 - **Control Panel**: Launch a local PHP server (`php -S localhost:8000`) and open [`reactor_control.php`](reactor_control.php) to track CPU, memory, and event metrics.
-- **API Examples**:
+- **API Endpoints**:
+  - `POST /api/v1/stargate/activate` — initiate stargate activation sequence
+  - `GET /api/v1/stargate/status` — retrieve current stargate status
+  - `POST /api/v1/stargate/deactivate` — shut down the stargate
+- **Example Commands**:
   ```bash
   # Activate the stargate
   curl -X POST http://localhost/api/v1/stargate/activate -H 'Content-Type: application/json' -d '{"destination":"EARTH-ALPHA"}'

--- a/technical_docs.php
+++ b/technical_docs.php
@@ -915,12 +915,17 @@ if __name__ == "__main__":
             <p>Use the auxiliary interfaces to manage releases and reactor operations.</p>
 
             <h3 id="downloads">10.1 Downloads Page</h3>
-            <p>Navigate to <a href="downloads.php">downloads.php</a> to fetch release artifacts and review available API endpoints.</p>
+            <p>Navigate to <a href="downloads.php">downloads.php</a> to download release artifacts and review available REST API endpoints.</p>
 
             <h3 id="control-panel">10.2 Control Panel</h3>
             <p>Start a local server with <code>php -S localhost:8000</code> and open <a href="reactor_control.php">reactor_control.php</a> to monitor CPU, memory, and event rates.</p>
 
             <h3 id="api-examples">10.3 API Examples</h3>
+            <ul>
+                <li><code>POST /api/v1/stargate/activate</code> – Initiate stargate activation sequence.</li>
+                <li><code>GET /api/v1/stargate/status</code> – Retrieve current stargate status.</li>
+                <li><code>POST /api/v1/stargate/deactivate</code> – Shut down the stargate.</li>
+            </ul>
             <pre><code class="language-bash">
 # Activate the stargate
 curl -X POST http://localhost/api/v1/stargate/activate -H 'Content-Type: application/json' -d '{"destination":"EARTH-ALPHA"}'


### PR DESCRIPTION
## Summary
- document how to use downloads.php and reactor_control.php
- add REST API endpoint summaries and example curl commands
- reference the ternary-fission-reactor repo for full installation guidance

## Testing
- `php -l technical_docs.php`
- `markdownlint README.md` *(reports style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6898ece98174832ba1c5e835bd2da8dd