### PR TITLE
feat: enhance navigation with fontawesome icons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -105,6 +105,13 @@ body {
     transition: all 0.3s ease;
     font-size: var(--font-small);
     white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-item a .nav-icon {
+    color: inherit;
 }
 
 .nav-item a:hover,
@@ -116,19 +123,12 @@ body {
 /* Mobile menu toggle (hidden on desktop) */
 .mobile-menu-toggle {
     display: none;
-    flex-direction: column;
     background: none;
     border: none;
     cursor: pointer;
     padding: 0.5rem;
-}
-
-.mobile-menu-toggle span {
-    width: 25px;
-    height: 3px;
-    background: var(--text-light);
-    margin: 2px 0;
-    transition: 0.3s;
+    color: var(--text-light);
+    font-size: 1.5rem;
 }
 
 /* Main Content Area */

--- a/header.php
+++ b/header.php
@@ -18,6 +18,9 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
     <!-- Shared CSS for all pages -->
     <link rel="stylesheet" href="css/main.css">
 
+    <!-- FontAwesome for icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+
     <!-- Page-specific CSS -->
     <?php if(file_exists("css/{$current_page}.css")): ?>
         <link rel="stylesheet" href="css/<?php echo $current_page; ?>.css">
@@ -42,41 +45,39 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 </a>
             </div>
 
-            <ul class="nav-menu">
+            <ul class="nav-menu" id="nav-menu">
                 <li class="nav-item <?php echo ($current_page == 'index') ? 'active' : ''; ?>">
-                    <a href="index.php">Overview</a>
+                    <a href="index.php"><i class="nav-icon fas fa-home" aria-hidden="true"></i>Overview</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'interactive_visualization') ? 'active' : ''; ?>">
-                    <a href="interactive_visualization.php">Visualizations</a>
+                    <a href="interactive_visualization.php"><i class="nav-icon fas fa-chart-bar" aria-hidden="true"></i>Visualizations</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'metrics_feasability_dashboard') ? 'active' : ''; ?>">
-                    <a href="metrics_feasability_dashboard.php">Metrics</a>
+                    <a href="metrics_feasability_dashboard.php"><i class="nav-icon fas fa-tachometer-alt" aria-hidden="true"></i>Metrics</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == '3d_interactive_model') ? 'active' : ''; ?>">
-                    <a href="3d_interactive_model.php">3D Model</a>
+                    <a href="3d_interactive_model.php"><i class="nav-icon fas fa-cube" aria-hidden="true"></i>3D Model</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'wormhole_travel_dashboard') ? 'active' : ''; ?>">
-                    <a href="wormhole_travel_dashboard.php">Simulator</a>
+                    <a href="wormhole_travel_dashboard.php"><i class="nav-icon fas fa-rocket" aria-hidden="true"></i>Simulator</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'presentation_builder') ? 'active' : ''; ?>">
-                    <a href="presentation_builder.php">Presentations</a>
+                    <a href="presentation_builder.php"><i class="nav-icon fas fa-chalkboard" aria-hidden="true"></i>Presentations</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'executive_summary_generator') ? 'active' : ''; ?>">
-                    <a href="executive_summary_generator.php">Summaries</a>
+                    <a href="executive_summary_generator.php"><i class="nav-icon fas fa-file-alt" aria-hidden="true"></i>Summaries</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'downloads') ? 'active' : ''; ?>">
-                    <a href="downloads.php">Downloads</a>
+                    <a href="downloads.php"><i class="nav-icon fas fa-download" aria-hidden="true"></i>Downloads</a>
                 </li>
                 <li class="nav-item <?php echo ($current_page == 'technical_docs') ? 'active' : ''; ?>">
-                    <a href="technical_docs.php">Documentation</a>
+                    <a href="technical_docs.php"><i class="nav-icon fas fa-book" aria-hidden="true"></i>Documentation</a>
                 </li>
             </ul>
 
             <!-- Mobile menu toggle -->
-            <button class="mobile-menu-toggle" id="mobile-menu-toggle">
-                <span></span>
-                <span></span>
-                <span></span>
+            <button class="mobile-menu-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation" aria-controls="nav-menu" aria-expanded="false">
+                <i class="fas fa-bars"></i>
             </button>
         </div>
     </nav>

--- a/js/main.js
+++ b/js/main.js
@@ -19,35 +19,35 @@ document.addEventListener('DOMContentLoaded', function() {
 function initMobileMenu() {
     const menuToggle = document.getElementById('mobile-menu-toggle');
     const navMenu = document.querySelector('.nav-menu');
-    
+
     if (menuToggle && navMenu) {
         menuToggle.addEventListener('click', function() {
             navMenu.classList.toggle('active');
-            
-            // Animate hamburger menu
-            const spans = this.querySelectorAll('span');
             this.classList.toggle('active');
-            
-            if (this.classList.contains('active')) {
-                spans[0].style.transform = 'rotate(45deg) translate(5px, 5px)';
-                spans[1].style.opacity = '0';
-                spans[2].style.transform = 'rotate(-45deg) translate(7px, -6px)';
-            } else {
-                spans[0].style.transform = 'none';
-                spans[1].style.opacity = '1';
-                spans[2].style.transform = 'none';
+
+            // Toggle menu icon
+            const icon = this.querySelector('i');
+            const expanded = this.getAttribute('aria-expanded') === 'true';
+            this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+
+            if (icon) {
+                icon.classList.toggle('fa-bars');
+                icon.classList.toggle('fa-times');
             }
         });
-        
+
         // Close menu when clicking outside
         document.addEventListener('click', function(e) {
             if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
                 navMenu.classList.remove('active');
                 menuToggle.classList.remove('active');
-                const spans = menuToggle.querySelectorAll('span');
-                spans[0].style.transform = 'none';
-                spans[1].style.opacity = '1';
-                spans[2].style.transform = 'none';
+                menuToggle.setAttribute('aria-expanded', 'false');
+
+                const icon = menuToggle.querySelector('i');
+                if (icon) {
+                    icon.classList.add('fa-bars');
+                    icon.classList.remove('fa-times');
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- load FontAwesome via CDN and add icons to navigation links
- replace hamburger spans with FontAwesome icon and ARIA attributes for accessibility
- style updated navigation and toggle; adjust JS for icon swapping

## Testing
- `php -l header.php`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6899044b8a5c832bb30c5f653ffe261b