### PR TITLE
feat: add off-canvas mobile nav with overlay

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -131,6 +131,30 @@ body {
     font-size: 1.5rem;
 }
 
+/* Overlay that appears when mobile menu is active */
+.nav-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.3s ease;
+    z-index: 1000;
+}
+
+.nav-overlay.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+/* Prevent body scrolling when menu is open */
+body.menu-open {
+    overflow: hidden;
+}
+
 /* Main Content Area */
 .main-content {
     flex: 1;
@@ -347,29 +371,38 @@ body {
     }
 }
 
+/* Desktop layouts */
+@media (min-width: 1024px) {
+    .nav-overlay {
+        display: none;
+    }
+}
+
 /* Tablet and smaller laptops */
-@media (max-width: 1024px) {
+@media (max-width: 1023px) {
     .nav-menu {
         position: fixed;
-        left: -100%;
-        top: 70px;
+        left: -250px;
+        top: 0;
         flex-direction: column;
         background: var(--secondary-color);
-        width: 100%;
-        text-align: center;
-        transition: 0.3s;
+        width: 250px;
+        height: 100vh;
+        text-align: left;
+        transition: left 0.3s ease;
         box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
-        padding: 2rem 0;
+        padding: 2rem 1rem;
+        z-index: 1001;
     }
-    
+
     .nav-menu.active {
         left: 0;
     }
-    
+
     .mobile-menu-toggle {
         display: flex;
     }
-    
+
     .grid-2,
     .grid-3,
     .grid-4 {

--- a/js/main.js
+++ b/js/main.js
@@ -19,11 +19,30 @@ document.addEventListener('DOMContentLoaded', function() {
 function initMobileMenu() {
     const menuToggle = document.getElementById('mobile-menu-toggle');
     const navMenu = document.querySelector('.nav-menu');
-
     if (menuToggle && navMenu) {
+        const overlay = document.createElement('div');
+        overlay.className = 'nav-overlay';
+        document.body.appendChild(overlay);
+
+        function closeMenu() {
+            navMenu.classList.remove('active');
+            menuToggle.classList.remove('active');
+            overlay.classList.remove('active');
+            document.body.classList.remove('menu-open');
+            menuToggle.setAttribute('aria-expanded', 'false');
+
+            const icon = menuToggle.querySelector('i');
+            if (icon) {
+                icon.classList.add('fa-bars');
+                icon.classList.remove('fa-times');
+            }
+        }
+
         menuToggle.addEventListener('click', function() {
-            navMenu.classList.toggle('active');
+            const isOpen = navMenu.classList.toggle('active');
             this.classList.toggle('active');
+            overlay.classList.toggle('active', isOpen);
+            document.body.classList.toggle('menu-open', isOpen);
 
             // Toggle menu icon
             const icon = this.querySelector('i');
@@ -36,18 +55,12 @@ function initMobileMenu() {
             }
         });
 
+        overlay.addEventListener('click', closeMenu);
+
         // Close menu when clicking outside
         document.addEventListener('click', function(e) {
             if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
-                navMenu.classList.remove('active');
-                menuToggle.classList.remove('active');
-                menuToggle.setAttribute('aria-expanded', 'false');
-
-                const icon = menuToggle.querySelector('i');
-                if (icon) {
-                    icon.classList.add('fa-bars');
-                    icon.classList.remove('fa-times');
-                }
+                closeMenu();
             }
         });
     }


### PR DESCRIPTION
## Summary
- add off-canvas mobile nav panel with semi-transparent overlay
- lock body scrolling and hide overlay on desktop
- toggle overlay and scroll lock via updated mobile menu script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990ccbfe28832b9e11117e38a1dba4