### PR TITLE
Add viewport-fit=cover to meta viewport for edge-to-edge displays

### DIFF
--- a/header.php
+++ b/header.php
@@ -12,7 +12,7 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Stargate Framework - <?php echo ucwords(str_replace('_', ' ', $current_page)); ?></title>
 
     <!-- Shared CSS for all pages -->


### PR DESCRIPTION
## Summary
- expand viewport meta tag to include `viewport-fit=cover` for full-bleed mobile layouts

## Testing
- `php -l header.php`
- `curl -s -A "Mozilla/5.0 (iPhone; ...)" http://127.0.0.1:8000/index.php | head -n 20`
- `curl -s -A "Mozilla/5.0 (X11; ...)" http://127.0.0.1:8000/index.php | head -n 20`
- `curl -sI -A "Mozilla/5.0 (iPhone; ...)" http://127.0.0.1:8000/css/main.css`
- `curl -sI -A "Mozilla/5.0 (X11; ...)" http://127.0.0.1:8000/css/main.css`


------
https://chatgpt.com/codex/tasks/task_e_689913bf4e24832b8c890233e5823877