### PR TITLE
test: configure acceptance suite to use local server

### DIFF
--- a/tests/Acceptance.suite.yml
+++ b/tests/Acceptance.suite.yml
@@ -7,7 +7,7 @@ actor: AcceptanceTester
 modules:
     enabled:
         - PhpBrowser:
-            url: http://localhost
+            url: http://localhost:8000
 # Add Codeception\Step\Retry trait to AcceptanceTester to enable retries
 step_decorators:
     - Codeception\Step\ConditionalAssertion

--- a/tests/Acceptance/PagesCest.php
+++ b/tests/Acceptance/PagesCest.php
@@ -8,24 +8,25 @@ class PagesCest
 {
     public function allPagesRespondSuccessfully(AcceptanceTester $I)
     {
+        $basePath = '/';
         $pages = [
-            '/',
-            '/index.php',
-            '/downloads.php',
-            '/reactor_control.php',
-            '/analytics.php',
-            '/interactive_visualization.php',
-            '/executive_summary_generator.php',
-            '/presentation_builder.php',
-            '/wormhole_travel_dashboard.php',
-            '/3d_interactive_model.php',
-            '/technical_docs.php',
-            '/test_setup.php',
-            '/metrics_feasability_dashboard.php'
+            '',
+            'index.php',
+            'downloads.php',
+            'reactor_control.php',
+            'analytics.php',
+            'interactive_visualization.php',
+            'executive_summary_generator.php',
+            'presentation_builder.php',
+            'wormhole_travel_dashboard.php',
+            '3d_interactive_model.php',
+            'technical_docs.php',
+            'test_setup.php',
+            'metrics_feasability_dashboard.php'
         ];
 
         foreach ($pages as $page) {
-            $I->amOnPage($page);
+            $I->amOnPage($basePath . $page);
             $I->seeResponseCodeIs(200);
         }
     }


### PR DESCRIPTION
## Summary
- point Acceptance tests to local PHP server on port 8000
- centralize public path handling in PagesCest

## Testing
- `php -S localhost:8000 >/tmp/php_server.log 2>&1 &`
- `vendor/bin/codecept run Acceptance tests/Acceptance/PagesCest.php`


------
https://chatgpt.com/codex/tasks/task_e_689925b2d0a0832bbc64bc8261eeef4e