### PR TITLE
Add PHP lint job and conditional Codeception tests

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -5,10 +5,26 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PHP
+        run: |
+          apt-get update
+          apt-get install -y php8.2-cli
+      - name: Lint PHP files
+        run: find . -name '*.php' -print0 | xargs -0 -n1 php -l
+
   test:
     runs-on: ubuntu-latest
     container:
       image: debian:12
+    strategy:
+      matrix:
+        run_codeception: [true]
     steps:
       - uses: actions/checkout@v3
       - name: Install system packages
@@ -49,9 +65,8 @@ PY
           done
       - name: Install PHP dependencies
         run: composer install --no-interaction --prefer-dist
-      - name: Lint PHP files
-        run: find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l
       - name: Run Codeception tests
+        if: matrix.run_codeception
         env:
           GO_API_BASE: http://localhost:8080/api/v1
         run: vendor/bin/codecept run Acceptance --skip-group php83

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Stargate Framework
 
+![Lint](https://github.com/davestj/stargate-framework/actions/workflows/dev.yaml/badge.svg?branch=main&job=lint)
+![Tests](https://github.com/davestj/stargate-framework/actions/workflows/dev.yaml/badge.svg?branch=main&job=test)
+
 **A Unified Theory for Wormhole Energy, FTL Propulsion, and Temporal Navigation Systems**
 
 ---


### PR DESCRIPTION
## Summary
- add standalone job to lint all PHP files
- gate Codeception tests with a matrix flag
- document lint and test status badges in README

## Testing
- `composer install --no-interaction --prefer-dist`
- `find . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n1 php -l`
- `vendor/bin/codecept run Acceptance --skip-group php83` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899299204f8832b845ed114058abbaa