### PR TITLE
Fix ternary reactor API step indentation

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -41,20 +41,20 @@ jobs:
           git clone https://github.com/davestj/ternary-fission-reactor.git /tmp/ternary-fission-reactor
           sed -i 's|reactor_base_url=.*|reactor_base_url=http://127.0.0.1:9999|' /tmp/ternary-fission-reactor/configs/ternary_fission.conf
           python3 - <<'PY' &
-from http.server import BaseHTTPRequestHandler, HTTPServer
-import json
-class Handler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        if self.path == '/api/v1/status':
-            self.send_response(200)
-            self.send_header('Content-Type','application/json')
-            self.end_headers()
-            self.wfile.write(json.dumps({'active_energy_fields':0}).encode())
-        else:
-            self.send_response(404)
-            self.end_headers()
-HTTPServer(('127.0.0.1',9999), Handler).serve_forever()
-PY
+            from http.server import BaseHTTPRequestHandler, HTTPServer
+            import json
+            class Handler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    if self.path == '/api/v1/status':
+                        self.send_response(200)
+                        self.send_header('Content-Type','application/json')
+                        self.end_headers()
+                        self.wfile.write(json.dumps({'active_energy_fields':0}).encode())
+                    else:
+                        self.send_response(404)
+                        self.end_headers()
+            HTTPServer(('127.0.0.1',9999), Handler).serve_forever()
+          PY
           (cd /tmp/ternary-fission-reactor && go run src/go/api.ternary.fission.server.go -port 8080 >/tmp/goapi.log 2>&1 &)
           for i in {1..30}; do
             if curl -fsS http://localhost:8080/api/v1/health >/dev/null; then


### PR DESCRIPTION
## Summary
- complete sed path and indent Python server snippet in ternary-fission-reactor setup

## Testing
- `yamllint .github/workflows/dev.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68992d66826c832b8b05ec861e93c8d3