### PR TITLE
Split navigation and add secondary drawer toggle

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -97,6 +97,27 @@ body {
     align-items: center;
 }
 
+.nav-secondary {
+    display: none;
+    position: fixed;
+    right: -250px;
+    top: 0;
+    flex-direction: column;
+    background: var(--secondary-color);
+    width: 250px;
+    height: 100vh;
+    text-align: left;
+    transition: right 0.3s ease;
+    box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
+    padding: 2rem 1rem;
+    z-index: 1001;
+}
+
+.nav-secondary.active {
+    right: 0;
+    display: flex;
+}
+
 .nav-item a {
     color: var(--text-light);
     text-decoration: none;
@@ -120,9 +141,8 @@ body {
     color: var(--primary-color);
 }
 
-/* Mobile menu toggle (hidden on desktop) */
-.mobile-menu-toggle {
-    display: none;
+/* Secondary navigation toggle */
+.nav-secondary-toggle {
     background: none;
     border: none;
     cursor: pointer;
@@ -380,29 +400,6 @@ body.menu-open {
 
 /* Tablet and smaller laptops */
 @media (max-width: 1023px) {
-    .nav-menu {
-        position: fixed;
-        left: -250px;
-        top: 0;
-        flex-direction: column;
-        background: var(--secondary-color);
-        width: 250px;
-        height: 100vh;
-        text-align: left;
-        transition: left 0.3s ease;
-        box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
-        padding: 2rem 1rem;
-        z-index: 1001;
-    }
-
-    .nav-menu.active {
-        left: 0;
-    }
-
-    .mobile-menu-toggle {
-        display: flex;
-    }
-
     .grid-2,
     .grid-3,
     .grid-4 {

--- a/header.php
+++ b/header.php
@@ -45,7 +45,7 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 </a>
             </div>
 
-            <ul class="nav-menu" id="nav-menu">
+            <ul class="nav-menu nav-primary" id="nav-primary">
                 <li class="nav-item <?php echo ($current_page == 'index') ? 'active' : ''; ?>">
                     <a href="index.php"><i class="nav-icon fas fa-home" aria-hidden="true"></i>Overview</a>
                 </li>
@@ -58,6 +58,13 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 <li class="nav-item <?php echo ($current_page == '3d_interactive_model') ? 'active' : ''; ?>">
                     <a href="3d_interactive_model.php"><i class="nav-icon fas fa-cube" aria-hidden="true"></i>3D Model</a>
                 </li>
+            </ul>
+
+            <button class="nav-secondary-toggle" id="nav-secondary-toggle" aria-label="Toggle navigation" aria-controls="nav-secondary" aria-expanded="false">
+                <i class="fas fa-bars"></i>
+            </button>
+
+            <ul class="nav-menu nav-secondary" id="nav-secondary">
                 <li class="nav-item <?php echo ($current_page == 'wormhole_travel_dashboard') ? 'active' : ''; ?>">
                     <a href="wormhole_travel_dashboard.php"><i class="nav-icon fas fa-rocket" aria-hidden="true"></i>Simulator</a>
                 </li>
@@ -74,11 +81,6 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                     <a href="technical_docs.php"><i class="nav-icon fas fa-book" aria-hidden="true"></i>Documentation</a>
                 </li>
             </ul>
-
-            <!-- Mobile menu toggle -->
-            <button class="mobile-menu-toggle" id="mobile-menu-toggle" aria-label="Toggle navigation" aria-controls="nav-menu" aria-expanded="false">
-                <i class="fas fa-bars"></i>
-            </button>
         </div>
     </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -6,19 +6,19 @@
 
 // I'm initializing the main JavaScript functionality when DOM loads
 document.addEventListener('DOMContentLoaded', function() {
-    initMobileMenu();
+    initSecondaryMenu();
     initSmoothScrolling();
     initPageTransitions();
     checkScreenSize();
 });
 
 /**
- * Mobile menu toggle functionality
- * This handles the hamburger menu for tablet and mobile devices
+ * Secondary navigation toggle functionality
+ * This handles the hamburger menu for additional navigation links
  */
-function initMobileMenu() {
-    const menuToggle = document.getElementById('mobile-menu-toggle');
-    const navMenu = document.querySelector('.nav-menu');
+function initSecondaryMenu() {
+    const menuToggle = document.getElementById('nav-secondary-toggle');
+    const navMenu = document.querySelector('.nav-secondary');
     if (menuToggle && navMenu) {
         const overlay = document.createElement('div');
         overlay.className = 'nav-overlay';


### PR DESCRIPTION
## Summary
- Separate header navigation into primary and secondary lists
- Add hamburger toggle button to reveal secondary links with ARIA attributes
- Implement JS and CSS for drawer-style secondary navigation

## Testing
- `php -l header.php`
- `node --check js/main.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689961575c40832ba23fcc155a43fffc