### PR TITLE
Move Downloads link to secondary navigation

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -104,6 +104,7 @@ body {
     transform: translateX(100%);
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     background: var(--secondary-color);
     width: 250px;
     height: 100vh;

--- a/header.php
+++ b/header.php
@@ -74,11 +74,11 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 <li class="nav-item <?php echo ($current_page == 'executive_summary_generator') ? 'active' : ''; ?>">
                     <a href="executive_summary_generator.php"><i class="nav-icon fas fa-file-alt" aria-hidden="true"></i>Summaries</a>
                 </li>
-                <li class="nav-item <?php echo ($current_page == 'downloads') ? 'active' : ''; ?>">
-                    <a href="downloads.php"><i class="nav-icon fas fa-download" aria-hidden="true"></i>Downloads</a>
-                </li>
                 <li class="nav-item <?php echo ($current_page == 'technical_docs') ? 'active' : ''; ?>">
                     <a href="technical_docs.php"><i class="nav-icon fas fa-book" aria-hidden="true"></i>Documentation</a>
+                </li>
+                <li class="nav-item <?php echo ($current_page == 'downloads') ? 'active' : ''; ?>">
+                    <a href="downloads.php"><i class="nav-icon fas fa-download" aria-hidden="true"></i>Downloads</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- shift Downloads menu item into the secondary slide-out navigation
- align slide-out list items by adding `align-items: flex-start`

## Testing
- `php -l header.php`
- `php -l index.php`
- `php index.php | rg -n "Downloads" -n`


------
https://chatgpt.com/codex/tasks/task_e_68996a353160832bae23dbf4b6cc00e8