### PR TITLE
Add off-canvas navigation with overlay

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -98,33 +98,13 @@ body {
     display: block;
 }
 
+
+/* Base navigation menu */
 .nav-menu {
     display: flex;
     list-style: none;
     gap: 1rem;
     align-items: center;
-}
-
-.nav-secondary {
-    position: fixed;
-    top: 0;
-    right: 0;
-    transform: translateX(100%);
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    background: var(--secondary-color);
-    width: 250px;
-    height: 100vh;
-    text-align: left;
-    transition: transform 0.3s ease;
-    box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
-    padding: 2rem 1rem;
-    z-index: 1001;
-}
-
-.nav-secondary.active {
-    transform: translateX(0);
 }
 
 .nav-item a {
@@ -160,7 +140,7 @@ body {
     padding: 0.5rem;
     color: var(--text-light);
     font-size: 1.5rem;
-    display: flex;
+    display: none;
     align-items: center;
 }
 
@@ -188,6 +168,58 @@ body.menu-open {
     overflow: hidden;
 }
 
+/* Responsive navigation behaviour */
+@media (max-width: 1023px) {
+    .nav-menu {
+        position: fixed;
+        top: 0;
+        right: 0;
+        transform: translateX(100%);
+        flex-direction: column;
+        align-items: flex-start;
+        background: var(--secondary-color);
+        width: 250px;
+        height: 100vh;
+        text-align: left;
+        transition: transform 0.3s ease;
+        box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
+        padding: 2rem 1rem;
+        z-index: 1001;
+    }
+
+    .nav-menu.active {
+        transform: translateX(0);
+    }
+
+    .nav-menu.nav-primary {
+        display: none;
+    }
+
+    .nav-secondary-toggle {
+        display: flex;
+    }
+}
+
+@media (min-width: 1024px) {
+    .nav-secondary-toggle {
+        display: none;
+    }
+
+    .nav-menu {
+        position: static;
+        transform: none;
+        flex-direction: row;
+        width: auto;
+        height: auto;
+        padding: 0;
+        background: none;
+        box-shadow: none;
+    }
+
+    .nav-menu.nav-secondary {
+        display: none;
+    }
+}
 /* Main Content Area */
 .main-content {
     flex: 1;

--- a/js/main.js
+++ b/js/main.js
@@ -20,16 +20,37 @@ function initMobileMenu() {
     const menuToggle = document.getElementById('nav-secondary-toggle');
     const navMenu = document.querySelector('.nav-secondary');
     if (menuToggle && navMenu) {
-        const overlay = document.createElement('div');
-        overlay.className = 'nav-overlay';
-        document.body.appendChild(overlay);
+        let overlay = null;
+
+        function openMenu() {
+            navMenu.classList.add('active');
+            menuToggle.classList.add('active');
+            menuToggle.setAttribute('aria-expanded', 'true');
+            document.body.classList.add('menu-open');
+
+            overlay = document.createElement('div');
+            overlay.className = 'nav-overlay';
+            document.body.appendChild(overlay);
+            overlay.addEventListener('click', closeMenu);
+
+            const icon = menuToggle.querySelector('i');
+            if (icon) {
+                icon.classList.add('fa-times');
+                icon.classList.remove('fa-bars');
+            }
+        }
 
         function closeMenu() {
             navMenu.classList.remove('active');
             menuToggle.classList.remove('active');
-            overlay.classList.remove('active');
-            document.body.classList.remove('menu-open');
             menuToggle.setAttribute('aria-expanded', 'false');
+            document.body.classList.remove('menu-open');
+
+            if (overlay) {
+                overlay.removeEventListener('click', closeMenu);
+                document.body.removeChild(overlay);
+                overlay = null;
+            }
 
             const icon = menuToggle.querySelector('i');
             if (icon) {
@@ -39,23 +60,13 @@ function initMobileMenu() {
         }
 
         menuToggle.addEventListener('click', function() {
-            const isOpen = navMenu.classList.toggle('active');
-            this.classList.toggle('active');
-            overlay.classList.toggle('active', isOpen);
-            document.body.classList.toggle('menu-open', isOpen);
-
-            // Toggle menu icon
-            const icon = this.querySelector('i');
-            const expanded = this.getAttribute('aria-expanded') === 'true';
-            this.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-
-            if (icon) {
-                icon.classList.toggle('fa-bars');
-                icon.classList.toggle('fa-times');
+            const isOpen = navMenu.classList.contains('active');
+            if (isOpen) {
+                closeMenu();
+            } else {
+                openMenu();
             }
         });
-
-        overlay.addEventListener('click', closeMenu);
 
         // Close menu when clicking outside
         document.addEventListener('click', function(e) {


### PR DESCRIPTION
## Summary
- Rework nav menu CSS to support off-canvas panel with overlay
- Add responsive media queries for desktop and mobile breakpoints
- Enhance mobile menu JS to create overlay, lock scrolling, and clean up on close

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `composer install --no-interaction --no-progress`


------
https://chatgpt.com/codex/tasks/task_e_689baff88a24832b95542a2863fcb8b8