### PR TITLE
ci: run acceptance suite only

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -40,4 +40,4 @@ jobs:
       - name: Lint PHP files
         run: find . -name '*.php' -print0 | xargs -0 -n1 php -l
       - name: Run Codeception tests
-        run: vendor/bin/codecept run --skip-group php83 --debug
+        run: vendor/bin/codecept run acceptance --skip-group php83


### PR DESCRIPTION
## Summary
- limit CI Codeception run to existing acceptance suite

## Testing
- `vendor/bin/codecept run acceptance --skip-group php83` *(fails: cURL error 7: Failed to connect to localhost port 80)*

------
https://chatgpt.com/codex/tasks/task_e_689bba217508832bbed5391756e64416