### PR TITLE
Add standalone PHP lint job and guard acceptance tests

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -5,10 +5,28 @@ on:
   pull_request:
 
 jobs:
-  test:
+  lint:
+    name: PHP Lint
     runs-on: ubuntu-latest
     container:
       image: debian:12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PHP CLI
+        run: |
+          apt-get update
+          apt-get install -y php8.2-cli
+      - name: Lint PHP files
+        run: find . -name '*.php' -print0 | xargs -0 -n1 php -l
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    container:
+      image: debian:12
+    strategy:
+      matrix:
+        run-codeception: [true]
     steps:
       - uses: actions/checkout@v3
       - name: Install system packages
@@ -55,7 +73,7 @@ jobs:
           exit 1
       - name: Composer install
         run: composer install
-      - name: Lint PHP files
-        run: find . -name '*.php' -print0 | xargs -0 -n1 php -l
       - name: Run Codeception tests
+        if: matrix.run-codeception
         run: vendor/bin/codecept run acceptance --skip-group php83
+


### PR DESCRIPTION
## Summary
- add `lint` job running `php -l` across all PHP files
- run Codeception acceptance tests only when matrix flag `run-codeception` is true

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`
- `composer install`
- `vendor/bin/codecept run acceptance --skip-group php83` *(fails: Failed to connect to localhost)*

------
https://chatgpt.com/codex/tasks/task_e_689bc1422efc832bae21445f94b8a297