### PR TITLE
chore: remove testing dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,6 @@
     "platform": {
       "php": "8.2"
     }
-  }
+  },
+  "require-dev": {}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "4d75be6e6ea28b50f4536ead3b25e4d4",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2"
+    },
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
## Summary
- drop Codeception and PHPUnit dev packages
- regenerate composer.lock without testing dependencies

## Testing
- `composer update`
- `composer update --lock`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_689bcda44f14832b9732f07fdba794e5