### PR TITLE
feat: add accessible secondary nav drawer

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -140,7 +140,7 @@ body {
     padding: 0.5rem;
     color: var(--text-light);
     font-size: 1.5rem;
-    display: none;
+    display: flex;
     align-items: center;
 }
 
@@ -168,57 +168,26 @@ body.menu-open {
     overflow: hidden;
 }
 
-/* Responsive navigation behaviour */
-@media (max-width: 1023px) {
-    .nav-menu {
-        position: fixed;
-        top: 0;
-        right: 0;
-        transform: translateX(100%);
-        flex-direction: column;
-        align-items: flex-start;
-        background: var(--secondary-color);
-        width: 250px;
-        height: 100vh;
-        text-align: left;
-        transition: transform 0.3s ease;
-        box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
-        padding: 2rem 1rem;
-        z-index: 1001;
-    }
-
-    .nav-menu.active {
-        transform: translateX(0);
-    }
-
-    .nav-menu.nav-primary {
-        display: none;
-    }
-
-    .nav-secondary-toggle {
-        display: flex;
-    }
+/* Secondary navigation drawer */
+.nav-menu.nav-secondary {
+    position: fixed;
+    top: 0;
+    right: 0;
+    transform: translateX(100%);
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--secondary-color);
+    width: 250px;
+    height: 100vh;
+    text-align: left;
+    transition: transform 0.3s ease;
+    box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
+    padding: 2rem 1rem;
+    z-index: 1001;
 }
 
-@media (min-width: 1024px) {
-    .nav-secondary-toggle {
-        display: none;
-    }
-
-    .nav-menu {
-        position: static;
-        transform: none;
-        flex-direction: row;
-        width: auto;
-        height: auto;
-        padding: 0;
-        background: none;
-        box-shadow: none;
-    }
-
-    .nav-menu.nav-secondary {
-        display: none;
-    }
+.nav-menu.nav-secondary.active {
+    transform: translateX(0);
 }
 /* Main Content Area */
 .main-content {

--- a/header.php
+++ b/header.php
@@ -48,7 +48,7 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 </a>
             </div>
 
-            <ul class="nav-menu nav-primary" id="nav-primary">
+            <ul class="nav-menu nav-primary" id="nav-primary" aria-label="Primary navigation">
                 <li class="nav-item <?php echo ($current_page == 'index') ? 'active' : ''; ?>">
                     <a href="index.php"><i class="nav-icon fas fa-home" aria-hidden="true"></i>Overview</a>
                 </li>
@@ -67,7 +67,7 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 <i class="fas fa-bars" aria-hidden="true"></i>
             </button>
 
-            <ul class="nav-menu nav-secondary" id="nav-secondary">
+            <ul class="nav-menu nav-secondary" id="nav-secondary" aria-hidden="true">
                 <li class="nav-item <?php echo ($current_page == 'wormhole_travel_dashboard') ? 'active' : ''; ?>">
                     <a href="wormhole_travel_dashboard.php"><i class="nav-icon fas fa-rocket" aria-hidden="true"></i>Simulator</a>
                 </li>

--- a/js/main.js
+++ b/js/main.js
@@ -18,12 +18,13 @@ document.addEventListener('DOMContentLoaded', function() {
  */
 function initMobileMenu() {
     const menuToggle = document.getElementById('nav-secondary-toggle');
-    const navMenu = document.querySelector('.nav-secondary');
+    const navMenu = document.getElementById('nav-secondary');
     if (menuToggle && navMenu) {
         let overlay = null;
 
         function openMenu() {
             navMenu.classList.add('active');
+            navMenu.setAttribute('aria-hidden', 'false');
             menuToggle.classList.add('active');
             menuToggle.setAttribute('aria-expanded', 'true');
             document.body.classList.add('menu-open');
@@ -42,6 +43,7 @@ function initMobileMenu() {
 
         function closeMenu() {
             navMenu.classList.remove('active');
+            navMenu.setAttribute('aria-hidden', 'true');
             menuToggle.classList.remove('active');
             menuToggle.setAttribute('aria-expanded', 'false');
             document.body.classList.remove('menu-open');


### PR DESCRIPTION
## Summary
- split site navigation into primary and secondary lists
- add hamburger toggle with aria attributes and drawer behavior
- enable secondary navigation on desktop and mobile

## Testing
- `php -l header.php`
- `node --check js/main.js`
- `composer validate --no-check-all` *(fails: The property name is required; The property description is required)*

------
https://chatgpt.com/codex/tasks/task_e_689bd2d5763c832bb7b60ab7c63570ec