### PR TITLE
Add off‑canvas secondary navigation with overlay

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -144,14 +144,14 @@ body {
     align-items: center;
 }
 
-/* Overlay that appears when mobile menu is active */
+/* Overlay that appears when the secondary navigation drawer is active */
 .nav-overlay {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
-    background: rgba(26, 26, 46, 0.8);
+    background: var(--secondary-color);
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.3s ease;
@@ -159,7 +159,7 @@ body {
 }
 
 .nav-overlay.active {
-    opacity: 1;
+    opacity: 0.8;
     visibility: visible;
 }
 
@@ -169,16 +169,19 @@ body.menu-open {
 }
 
 /* Secondary navigation drawer */
-.nav-menu.nav-secondary {
+.nav-secondary {
     position: fixed;
     top: 0;
     right: 0;
     transform: translateX(100%);
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
+    gap: 1rem;
     background: var(--secondary-color);
     width: 250px;
     height: 100vh;
+    color: var(--text-light);
     text-align: left;
     transition: transform 0.3s ease;
     box-shadow: 0 10px 27px rgba(0, 0, 0, 0.05);
@@ -186,7 +189,7 @@ body.menu-open {
     z-index: 1001;
 }
 
-.nav-menu.nav-secondary.active {
+.nav-secondary.active {
     transform: translateX(0);
 }
 /* Main Content Area */

--- a/js/main.js
+++ b/js/main.js
@@ -20,7 +20,9 @@ function initMobileMenu() {
     const menuToggle = document.getElementById('nav-secondary-toggle');
     const navMenu = document.getElementById('nav-secondary');
     if (menuToggle && navMenu) {
-        let overlay = null;
+        const overlay = document.createElement('div');
+        overlay.className = 'nav-overlay';
+        document.body.appendChild(overlay);
 
         function openMenu() {
             navMenu.classList.add('active');
@@ -28,11 +30,7 @@ function initMobileMenu() {
             menuToggle.classList.add('active');
             menuToggle.setAttribute('aria-expanded', 'true');
             document.body.classList.add('menu-open');
-
-            overlay = document.createElement('div');
-            overlay.className = 'nav-overlay';
-            document.body.appendChild(overlay);
-            overlay.addEventListener('click', closeMenu);
+            overlay.classList.add('active');
 
             const icon = menuToggle.querySelector('i');
             if (icon) {
@@ -47,12 +45,7 @@ function initMobileMenu() {
             menuToggle.classList.remove('active');
             menuToggle.setAttribute('aria-expanded', 'false');
             document.body.classList.remove('menu-open');
-
-            if (overlay) {
-                overlay.removeEventListener('click', closeMenu);
-                document.body.removeChild(overlay);
-                overlay = null;
-            }
+            overlay.classList.remove('active');
 
             const icon = menuToggle.querySelector('i');
             if (icon) {
@@ -70,12 +63,7 @@ function initMobileMenu() {
             }
         });
 
-        // Close menu when clicking outside
-        document.addEventListener('click', function(e) {
-            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
-                closeMenu();
-            }
-        });
+        overlay.addEventListener('click', closeMenu);
     }
 }
 


### PR DESCRIPTION
## Summary
- style `.nav-secondary` as an off‑canvas drawer with a theme-aware `.nav-overlay`
- toggle the drawer on all screen sizes, locking body scroll and closing on overlay click

## Testing
- `npm test` *(fails: missing package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bd44c85f0832bad706c911e95b89d