### PR TITLE
Clarify Downloads in secondary nav and reset list margins

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -103,6 +103,8 @@ body {
 .nav-menu {
     display: flex;
     list-style: none;
+    margin: 0;
+    padding: 0;
     gap: 1rem;
     align-items: center;
 }

--- a/header.php
+++ b/header.php
@@ -80,6 +80,7 @@ $current_page = basename($_SERVER['PHP_SELF'], '.php');
                 <li class="nav-item <?php echo ($current_page == 'technical_docs') ? 'active' : ''; ?>">
                     <a href="technical_docs.php"><i class="nav-icon fas fa-book" aria-hidden="true"></i>Documentation</a>
                 </li>
+                <!-- Downloads moved to secondary navigation for slide-out menu -->
                 <li class="nav-item <?php echo ($current_page == 'downloads') ? 'active' : ''; ?>">
                     <a href="downloads.php"><i class="nav-icon fas fa-download" aria-hidden="true"></i>Downloads</a>
                 </li>


### PR DESCRIPTION
## Summary
- Document that the Downloads link lives in the slide-out secondary navigation
- Reset navigation list margins and padding for consistent styling

## Testing
- `php -l header.php`
- `npx stylelint css/main.css` *(fails: Need to install stylelint@16.23.1)*
- `curl -A "Mozilla/5.0 (X11; Linux x86_64)" -s http://127.0.0.1:8000/index.php | sed -n '54,70p'`
- `curl -A "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X)" -s http://127.0.0.1:8000/index.php | sed -n '54,70p'`


------
https://chatgpt.com/codex/tasks/task_e_689bdc4b7424832b901d23ba29a3cbe7